### PR TITLE
show bug fix.

### DIFF
--- a/paper-typeahead.js
+++ b/paper-typeahead.js
@@ -249,8 +249,18 @@
           this, results, typedValue, dataKey).slice(0, maxResults);
 
         this.set('filteredItems', filteredItems);
-        this.set('_hideResults', filteredItems.length === 0);
+        this.set('_hideResults', !this._canShowResults(filteredItems));
       });
+    },
+
+    /**
+     * @private
+     * @param {!Array<?>} results
+     * @return {boolean}
+     */
+    _canShowResults: function(results) {
+      return (document.activeElement === this.$.input ||
+          this.root.activeElement === this.$.input)
     },
 
     _updateItems: function() {
@@ -288,7 +298,7 @@
     tryDisplayResults: function() {
       var items = this.filteredItems;
 
-      if (this._hideResults && items && items.length) {
+      if (this._hideResults && this._canShowResults(items)) {
         this.set('_hideResults', false);
       }
 

--- a/paper-typeahead.js
+++ b/paper-typeahead.js
@@ -38,6 +38,9 @@
         value: false
       },
 
+      /**
+       * Allows a user to show all typeahead results even when there is no input.
+       */
       showEmptyResults: {
         type: Boolean,
         value: false
@@ -91,6 +94,9 @@
         value: '',
       },
 
+      /**
+       * The max number of results to show to pick from when showing selectable items.
+       */
       maxResults: {
         type: Number,
         value: 10


### PR DESCRIPTION
This is to fix a bug that was introduced in the last release where, if
the typed value or backing data changed, the results would be opened
even if the user did not have focus.

Fixes #39