### PR TITLE
Add proper slots

### DIFF
--- a/paper-typeahead.html
+++ b/paper-typeahead.html
@@ -124,7 +124,7 @@ Custom property | Description | Default
         disabled$="[[disabled]]"
         invalid="[[invalid]]">
       <slot name="prefix" slot="prefix"></slot>
-      <label hidden$="[[!label]]" on-tap="_onLabelTap" slot="input">[[label]]</label>
+      <label hidden$="[[!label]]" on-tap="_onLabelTap" slot="label">[[label]]</label>
       <input
           is="iron-input"
           id="input"
@@ -156,7 +156,7 @@ Custom property | Description | Default
           autocorrect$="on"
           on-change="_onChange" slot="input">
       <slot name="suffix" slot="suffix"></slot>
-      <paper-input-error tabindex="-1" slot="input">[[errorMessage]]</paper-input-error>
+      <paper-input-error tabindex="-1" slot="add-on">[[errorMessage]]</paper-input-error>
     </paper-input-container>
     <paper-material
       hidden$="[[_hideResults]]"


### PR DESCRIPTION
The current slots will break in the upcoming change to paper-input. These slots should work on both the current and future paper-input.